### PR TITLE
No postmortem on Keyboard interrupts

### DIFF
--- a/flatsurvey/worker/__main__.py
+++ b/flatsurvey/worker/__main__.py
@@ -147,7 +147,7 @@ def process(commands, debug):
                 continue
 
             break
-    except:
+    except Exception:
         if debug:
             pdb.post_mortem()
         raise


### PR DESCRIPTION
why would we want to intercept any throwable here? If this is really
necessary, it should be documented better.