### PR TITLE
Fix Boshernitzan conjecture check

### DIFF
--- a/flatsurvey/jobs/boshernitzan_conjecture.py
+++ b/flatsurvey/jobs/boshernitzan_conjecture.py
@@ -227,22 +227,23 @@ class BoshernitzanConjecture(Goal):
             [Ngon([1, 1, 1])] [BoshernitzanConjecture] True
 
         """
-        if decomposition.minimalComponents():
-            await self.report(False)
-            return Goal.COMPLETED
-
         if decomposition.undeterminedComponents():
             await self.report(None)
             return Goal.COMPLETED
 
+        if decomposition.minimalComponents():
+            # Continue until all Boshernitzan conjecture directions have been checked.
+            return not Goal.COMPLETED
+
         assert all(component.cylinder() for component in decomposition.components())
 
-        return not Goal.COMPLETED
+        await self.report(True)
+        return Goal.COMPLETED
 
     async def report(self, result=None, **kwargs):
         if self._resolved != Goal.COMPLETED:
             if result is None and self._saddle_connection_orientations.exhausted:
-                result = True
+                result = False
 
             await self._report.result(
                 self,

--- a/flatsurvey/jobs/boshernitzan_conjecture.py
+++ b/flatsurvey/jobs/boshernitzan_conjecture.py
@@ -198,33 +198,14 @@ class BoshernitzanConjecture(Goal):
             >>> log = Log(surface=surface)
             >>> goal = BoshernitzanConjecture(report=Report([log]), flow_decompositions=FlowDecompositions(surface=surface, saddle_connection_orientations=orientations, report=Report([])), saddle_connection_orientations=orientations, cache=Cache())
 
-        Investigate in a single direction::
+        We investigate in a single direction and conclude that Boshernitzan's
+        conjecture holds for this triangle::
 
             >>> import asyncio
             >>> produce = orientations.produce()
             >>> asyncio.run(produce)
-            True
-
-        Since we have not found any direction that is not cylinder periodic
-        (since there are none), we cannot tell yet whether Boshernitzan's
-        conjectures hold::
-
-            >>> report = goal.report()
-            >>> asyncio.run(report)
-            [Ngon([1, 1, 1])] [BoshernitzanConjecture] ¯\_(ツ)_/¯
-
-        If we try to investigate in another direction, we find that we have
-        considered all possible directions::
-
-            >>> produce = orientations.produce()
-            >>> asyncio.run(produce)
-            False
-
-        So, we conclude that the Boshernitzan's conjecture holds for this
-        surface::
-
-            >>> asyncio.run(goal.report())
             [Ngon([1, 1, 1])] [BoshernitzanConjecture] True
+            True
 
         """
         if decomposition.undeterminedComponents():


### PR DESCRIPTION
all directions need to be minimal for Boshernitzan's conjecture to fail.

A few (known) directions had reported the conjecture to be false because of a single minimal direction. These have been manually deleted from the database.