### PR TITLE
Speed up Ngon.unfolding_symmetries()

### DIFF
--- a/flatsurvey/surfaces/ngons.py
+++ b/flatsurvey/surfaces/ngons.py
@@ -261,13 +261,15 @@ class Ngon(Surface):
         for (sign, x, y) in S.label_iterator():
             from sage.all import matrix
 
-            symmetries.add(matrix(
-                [
-                    [x, y],
-                    [-y, x],
-                ],
-                immutable=True,
-            ))
+            symmetries.add(
+                matrix(
+                    [
+                        [x, y],
+                        [-y, x],
+                    ],
+                    immutable=True,
+                )
+            )
 
         return symmetries
 

--- a/flatsurvey/surfaces/ngons.py
+++ b/flatsurvey/surfaces/ngons.py
@@ -254,36 +254,20 @@ class Ngon(Surface):
         """
         S = self._surface()
 
-        symmetries = []
+        symmetries = set()
 
         assert (0, 1, 0) in S.label_iterator()
 
         for (sign, x, y) in S.label_iterator():
             from sage.all import matrix
 
-            symmetry = matrix(
+            symmetries.add(matrix(
                 [
                     [x, y],
                     [-y, x],
                 ],
                 immutable=True,
-            )
-            symmetries.append(symmetry)
-
-        for symmetry in symmetries:
-            symmetry.set_immutable()
-
-        symmetries = set(symmetries)
-
-        assert any(
-            m == 1 for m in symmetries
-        ), f"The identity matrix must be contained in the symmetries but is not in {symmetries}."
-
-        for a in symmetries:
-            for b in symmetries:
-                other = a * ~b
-                other.set_immutable()
-                assert other in symmetries
+            ))
 
         return symmetries
 


### PR DESCRIPTION
by not checking that result is actually a group. We just have to trust
that sage-flatsurf does the right thing here since the actual
verification is extremely expensive.